### PR TITLE
Update F1 2026 race start times with actual UTC datetimes

### DIFF
--- a/internal/calendar/events.go
+++ b/internal/calendar/events.go
@@ -1,30 +1,30 @@
 package calendar
 
 var events = eventList{
-	{"AUS", "2026-03-08T00:00:00Z", f1Image}, // Australian Grand Prix
-	{"CHN", "2026-03-15T00:00:00Z", f1Image}, // Chinese Grand Prix
-	{"JPN", "2026-03-29T00:00:00Z", f1Image}, // Japanese Grand Prix
-	{"BHR", "2026-04-12T00:00:00Z", f1Image}, // Bahrain Grand Prix
-	{"SAU", "2026-04-19T00:00:00Z", f1Image}, // Saudi Arabian Grand Prix
-	{"MIA", "2026-05-03T00:00:00Z", f1Image}, // Miami Grand Prix
-	{"CAN", "2026-05-24T00:00:00Z", f1Image}, // Canadian Grand Prix
-	{"MON", "2026-06-07T00:00:00Z", f1Image}, // Monaco Grand Prix
-	{"CAT", "2026-06-14T00:00:00Z", f1Image}, // Barcelona-Catalunya Grand Prix
-	{"AUT", "2026-06-28T00:00:00Z", f1Image}, // Austrian Grand Prix
-	{"GBR", "2026-07-05T00:00:00Z", f1Image}, // British Grand Prix
-	{"BEL", "2026-07-19T00:00:00Z", f1Image}, // Belgian Grand Prix
-	{"HUN", "2026-07-26T00:00:00Z", f1Image}, // Hungarian Grand Prix
-	{"NED", "2026-08-23T00:00:00Z", f1Image}, // Dutch Grand Prix
-	{"ITA", "2026-09-06T00:00:00Z", f1Image}, // Italian Grand Prix
-	{"ESP", "2026-09-13T00:00:00Z", f1Image}, // Spanish Grand Prix
-	{"AZE", "2026-09-27T00:00:00Z", f1Image}, // Azerbaijan Grand Prix
-	{"SGP", "2026-10-11T00:00:00Z", f1Image}, // Singapore Grand Prix
-	{"USA", "2026-10-25T00:00:00Z", f1Image}, // United States Grand Prix
-	{"MEX", "2026-11-01T00:00:00Z", f1Image}, // Mexican Grand Prix
-	{"BRA", "2026-11-08T00:00:00Z", f1Image}, // Brazilian Grand Prix
-	{"LAS", "2026-11-21T00:00:00Z", f1Image}, // Las Vegas Grand Prix
-	{"QAT", "2026-11-29T00:00:00Z", f1Image}, // Qatar Grand Prix
-	{"UAE", "2026-12-06T00:00:00Z", f1Image}, // Abu Dhabi Grand Prix
+	{"AUS", "2026-03-08T04:00:00Z", f1Image}, // Australian Grand Prix (Melbourne, AEDT 15:00)
+	{"CHN", "2026-03-15T07:00:00Z", f1Image}, // Chinese Grand Prix (Shanghai, CST 15:00)
+	{"JPN", "2026-03-29T05:00:00Z", f1Image}, // Japanese Grand Prix (Suzuka, JST 14:00)
+	{"BHR", "2026-04-12T15:00:00Z", f1Image}, // Bahrain Grand Prix (Sakhir, AST 18:00)
+	{"SAU", "2026-04-19T17:00:00Z", f1Image}, // Saudi Arabian Grand Prix (Jeddah, AST 20:00)
+	{"MIA", "2026-05-03T20:00:00Z", f1Image}, // Miami Grand Prix (Miami, EDT 16:00)
+	{"CAN", "2026-05-24T20:00:00Z", f1Image}, // Canadian Grand Prix (Montreal, EDT 16:00)
+	{"MON", "2026-06-07T13:00:00Z", f1Image}, // Monaco Grand Prix (CEST 15:00)
+	{"CAT", "2026-06-14T13:00:00Z", f1Image}, // Barcelona-Catalunya Grand Prix (CEST 15:00)
+	{"AUT", "2026-06-28T13:00:00Z", f1Image}, // Austrian Grand Prix (Spielberg, CEST 15:00)
+	{"GBR", "2026-07-05T14:00:00Z", f1Image}, // British Grand Prix (Silverstone, BST 15:00)
+	{"BEL", "2026-07-19T13:00:00Z", f1Image}, // Belgian Grand Prix (Spa, CEST 15:00)
+	{"HUN", "2026-07-26T13:00:00Z", f1Image}, // Hungarian Grand Prix (Budapest, CEST 15:00)
+	{"NED", "2026-08-23T13:00:00Z", f1Image}, // Dutch Grand Prix (Zandvoort, CEST 15:00)
+	{"ITA", "2026-09-06T13:00:00Z", f1Image}, // Italian Grand Prix (Monza, CEST 15:00)
+	{"ESP", "2026-09-13T13:00:00Z", f1Image}, // Spanish Grand Prix (Madrid, CEST 15:00)
+	{"AZE", "2026-09-26T11:00:00Z", f1Image}, // Azerbaijan Grand Prix (Baku, AZT 15:00, Saturday race)
+	{"SGP", "2026-10-11T12:00:00Z", f1Image}, // Singapore Grand Prix (SGT 20:00)
+	{"USA", "2026-10-25T20:00:00Z", f1Image}, // United States Grand Prix (Austin, CDT 15:00)
+	{"MEX", "2026-11-01T20:00:00Z", f1Image}, // Mexican Grand Prix (Mexico City, CST 14:00)
+	{"BRA", "2026-11-08T17:00:00Z", f1Image}, // Brazilian Grand Prix (São Paulo, BRT 14:00)
+	{"LAS", "2026-11-22T04:00:00Z", f1Image}, // Las Vegas Grand Prix (PST 20:00 Sat, UTC Sun)
+	{"QAT", "2026-11-29T16:00:00Z", f1Image}, // Qatar Grand Prix (Lusail, AST 19:00)
+	{"UAE", "2026-12-06T13:00:00Z", f1Image}, // Abu Dhabi Grand Prix (Yas Marina, GST 17:00)
 
 	{"Eurovision", "2026-05-16T19:00:00Z", nil}, // Eurovision Song Contest
 


### PR DESCRIPTION
## Summary

- Replace placeholder `00:00:00Z` timestamps in `events.go` with official race start times converted to UTC
- Fix Azerbaijan race date from Sep 27 → Sep 26 (Saturday race)
- Fix Las Vegas race datetime from Nov 21 `00:00Z` → Nov 22 `04:00Z` (20:00 PST Saturday crosses midnight into Sunday UTC)

## Times source

Official 2026 F1 season start time announcement, converted from local times:
- European races: CEST (UTC+2) or BST (UTC+1) at 15:00 local
- Night races: Bahrain/Saudi (AST 18:00/20:00), Singapore (SGT 20:00), Las Vegas (PST 20:00), Qatar (AST 19:00)
- Fly-away races: Australia (AEDT 15:00), China (CST 15:00), Japan (JST 14:00), Azerbaijan (AZT 15:00), Americas (EDT/CDT/CST/BRT 14:00–16:00)

https://claude.ai/code/session_0116oWGH8Kr7A1xbXuCefXz1