### PR TITLE
Configurable timezone and centralised settings loading via config package

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ LED_HARDWARE=adafruit-hat
 
 # General
 DEBUG=false
+TIMEZONE=Europe/London
 
 # Calendar (optional) — comma-separated list of YAML files to load at runtime
 CALENDAR_FILES=/path/to/my-events.yaml,/path/to/led/calendars/f1.yaml

--- a/clock/clock.go
+++ b/clock/clock.go
@@ -4,18 +4,15 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"image"
 	"image/color"
 	_ "image/png"
 	"log"
-	"os"
-	"strconv"
-	"strings"
 	"sync/atomic"
 	"time"
 
+	"github.com/g-wilson/led/config"
 	"github.com/g-wilson/led/internal/calendar"
 	"github.com/g-wilson/led/internal/diagnostics"
 	"github.com/g-wilson/led/internal/hasensors"
@@ -23,7 +20,6 @@ import (
 	"github.com/g-wilson/led/internal/tomorrowio"
 	"github.com/g-wilson/led/internal/weather"
 
-	"github.com/joho/godotenv"
 	"github.com/toelsiba/fopix"
 	"golang.org/x/image/draw"
 )
@@ -45,18 +41,13 @@ type ClockRenderer struct {
 	debug        bool
 }
 
-func New(ctx context.Context) (*ClockRenderer, error) {
-	err := godotenv.Load()
-	if err != nil {
-		return nil, fmt.Errorf("error loading .env file: %w", err)
-	}
-
-	if err := calendar.Load(); err != nil {
+func New(ctx context.Context, cfg *config.Settings) (*ClockRenderer, error) {
+	if err := calendar.Load(cfg.CalendarFiles); err != nil {
 		return nil, fmt.Errorf("error loading calendar: %w", err)
 	}
 
 	fontInfo := fopix.FontInfo{}
-	err = json.Unmarshal(fontSource, &fontInfo)
+	err := json.Unmarshal(fontSource, &fontInfo)
 	if err != nil {
 		return nil, fmt.Errorf("error loading font info file: %w", err)
 	}
@@ -66,17 +57,11 @@ func New(ctx context.Context) (*ClockRenderer, error) {
 	}
 	font.SetScale(1)
 
-	tomorrowIoAPIKey := os.Getenv("TOMORROWIO_API_KEY")
-	if len(tomorrowIoAPIKey) == 0 {
-		return nil, errors.New("environment variable TOMORROWIO_API_KEY is required")
-	}
-
-	tomorrowIoClient := tomorrowio.New(tomorrowIoAPIKey, nil)
-	weatherRefresh, _ := strconv.ParseInt(os.Getenv("WEATHER_REFRESH"), 10, 32)
+	tomorrowIoClient := tomorrowio.New(cfg.TomorrowIOAPIKey, nil)
 	weatherAgent, err := weather.New(ctx, tomorrowIoClient, weather.AgentOptions{
-		Refresh:   int(weatherRefresh),
-		Latitude:  os.Getenv("WEATHER_LATITUDE"),
-		Longitude: os.Getenv("WEATHER_LONGITUDE"),
+		Refresh:   cfg.WeatherRefresh,
+		Latitude:  cfg.WeatherLatitude,
+		Longitude: cfg.WeatherLongitude,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initiating weather agent: %w", err)
@@ -87,11 +72,7 @@ func New(ctx context.Context) (*ClockRenderer, error) {
 		return nil, fmt.Errorf("error initiating diagnostics agent: %w", err)
 	}
 
-	timezone := os.Getenv("TIMEZONE")
-	if timezone == "" {
-		timezone = "Europe/London"
-	}
-	location, err := time.LoadLocation(timezone)
+	location, err := time.LoadLocation(cfg.Timezone)
 	if err != nil {
 		return nil, fmt.Errorf("cannot determine timezone: %w", err)
 	}
@@ -102,7 +83,7 @@ func New(ctx context.Context) (*ClockRenderer, error) {
 		diagnostics:  diagAgent,
 		location:     location,
 		pageInterval: 5 * time.Second,
-		debug:        os.Getenv("DEBUG") == "true",
+		debug:        cfg.Debug,
 	}
 
 	// Phase 1: static pages
@@ -114,15 +95,10 @@ func New(ctx context.Context) (*ClockRenderer, error) {
 		r.renderDiag,
 	}
 
-	// Phase 2: dynamic area pages (skipped entirely if HA env vars not set)
-	haURL := os.Getenv("HA_URL")
-	haToken := os.Getenv("HA_TOKEN")
-	haSensorsEnv := os.Getenv("HA_SENSORS")
-
-	if haURL != "" && haToken != "" && haSensorsEnv != "" {
-		haEntityIDs := strings.Split(haSensorsEnv, ",")
-		haClient := homeassistant.New(haURL, haToken, nil)
-		sensorsAgent, err := hasensors.New(ctx, haClient, haEntityIDs)
+	// Phase 2: dynamic area pages (skipped entirely if HA settings not provided)
+	if cfg.HAURL != "" && cfg.HAToken != "" && len(cfg.HASensors) > 0 {
+		haClient := homeassistant.New(cfg.HAURL, cfg.HAToken, nil)
+		sensorsAgent, err := hasensors.New(ctx, haClient, cfg.HASensors)
 		if err != nil {
 			log.Printf("sensors agent unavailable, skipping area pages: %v", err)
 		} else {

--- a/clock/clock.go
+++ b/clock/clock.go
@@ -87,7 +87,11 @@ func New(ctx context.Context) (*ClockRenderer, error) {
 		return nil, fmt.Errorf("error initiating diagnostics agent: %w", err)
 	}
 
-	location, err := time.LoadLocation("Europe/London")
+	timezone := os.Getenv("TIMEZONE")
+	if timezone == "" {
+		timezone = "Europe/London"
+	}
+	location, err := time.LoadLocation(timezone)
 	if err != nil {
 		return nil, fmt.Errorf("cannot determine timezone: %w", err)
 	}

--- a/cmd/debug-window/main.go
+++ b/cmd/debug-window/main.go
@@ -4,36 +4,27 @@ import (
 	"context"
 	"image"
 	"log"
-	"os"
 	"os/signal"
 	"runtime"
-	"strconv"
 	"syscall"
 
 	"github.com/g-wilson/led/clock"
+	"github.com/g-wilson/led/config"
 	"github.com/g-wilson/led/internal/framestreamer"
 	"github.com/g-wilson/led/internal/windowrenderer"
 
 	"github.com/go-gl/glfw/v3.3/glfw"
-	"github.com/joho/godotenv"
 )
-
-func init() {
-	err := godotenv.Load()
-	if err != nil {
-		log.Fatal("Error loading .env file")
-	}
-}
 
 func main() {
 	// Lock the main goroutine to the OS thread (required for GLFW on macOS)
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	rows, _ := strconv.ParseInt(os.Getenv("LED_ROWS"), 10, 32)
-	cols, _ := strconv.ParseInt(os.Getenv("LED_COLS"), 10, 32)
-	ledRows := int(rows)
-	ledCols := int(cols)
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalln(err)
+	}
 
 	// Initialize GLFW (must be on main thread on macOS)
 	if err := glfw.Init(); err != nil {
@@ -45,7 +36,7 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	clockApp, err := clock.New(ctx)
+	clockApp, err := clock.New(ctx, cfg)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -54,14 +45,14 @@ func main() {
 	fs := framestreamer.New(framestreamer.Params{
 		Bounds: image.Rectangle{
 			Min: image.Point{X: 0, Y: 0},
-			Max: image.Point{X: ledCols, Y: ledRows},
+			Max: image.Point{X: cfg.LEDCols, Y: cfg.LEDRows},
 		},
 		FrametimeMs: framestreamer.OneFPS,
 		Renderer:    clockApp,
 	})
 
 	// Create window renderer with direct channel access to framestreamer
-	renderer, err := windowrenderer.New("LED Matrix Debug", ledRows, ledCols, fs.C, fs.E)
+	renderer, err := windowrenderer.New("LED Matrix Debug", cfg.LEDRows, cfg.LEDCols, fs.C, fs.E)
 	if err != nil {
 		log.Fatalln("failed to create window renderer:", err)
 	}

--- a/cmd/debug/main.go
+++ b/cmd/debug/main.go
@@ -7,35 +7,28 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"strconv"
 	"syscall"
 
 	"github.com/g-wilson/led/clock"
+	"github.com/g-wilson/led/config"
 	"github.com/g-wilson/led/internal/framestreamer"
-
-	"github.com/joho/godotenv"
 )
 
-func init() {
-	err := godotenv.Load()
-	if err != nil {
-		log.Fatal("Error loading .env file")
-	}
-}
-
 func main() {
-	rows, _ := strconv.ParseInt(os.Getenv("LED_ROWS"), 10, 32)
-	cols, _ := strconv.ParseInt(os.Getenv("LED_COLS"), 10, 32)
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalln(err)
+	}
 
 	bounds := image.Rectangle{
 		Min: image.Point{X: 0, Y: 0},
-		Max: image.Point{X: int(cols), Y: int(rows)},
+		Max: image.Point{X: cfg.LEDCols, Y: cfg.LEDRows},
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	clockApp, err := clock.New(ctx)
+	clockApp, err := clock.New(ctx, cfg)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/cmd/pi/main.go
+++ b/cmd/pi/main.go
@@ -6,42 +6,31 @@ import (
 	"image/color"
 	"image/draw"
 	"log"
-	"os"
 	"os/signal"
-	"strconv"
 	"syscall"
 
 	"github.com/g-wilson/led/clock"
+	"github.com/g-wilson/led/config"
 	"github.com/g-wilson/led/internal/framestreamer"
 
-	"github.com/joho/godotenv"
 	rgbmatrix "github.com/mcuadros/go-rpi-rgb-led-matrix"
 )
 
-func init() {
-	err := godotenv.Load()
-	if err != nil {
-		log.Fatal("Error loading .env file")
-	}
-}
-
 func main() {
-	config := &rgbmatrix.DefaultConfig
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalln(err)
+	}
 
-	rows, _ := strconv.ParseInt(os.Getenv("LED_ROWS"), 10, 32)
-	cols, _ := strconv.ParseInt(os.Getenv("LED_COLS"), 10, 32)
-	pwmb, _ := strconv.ParseInt(os.Getenv("LED_PWM_BITS"), 10, 32)
-	pwmlsb, _ := strconv.ParseInt(os.Getenv("LED_PWM_LSB"), 10, 32)
-	brt, _ := strconv.ParseInt(os.Getenv("LED_BRIGHTNESS"), 10, 32)
+	matrixConfig := &rgbmatrix.DefaultConfig
+	matrixConfig.Rows = cfg.LEDRows
+	matrixConfig.Cols = cfg.LEDCols
+	matrixConfig.PWMBits = cfg.LEDPWMBits
+	matrixConfig.PWMLSBNanoseconds = cfg.LEDPWMLSBNano
+	matrixConfig.Brightness = cfg.LEDBrightness
+	matrixConfig.HardwareMapping = cfg.LEDHardware
 
-	config.Rows = int(rows)
-	config.Cols = int(cols)
-	config.PWMBits = int(pwmb)
-	config.PWMLSBNanoseconds = int(pwmlsb)
-	config.Brightness = int(brt)
-	config.HardwareMapping = os.Getenv("LED_HARDWARE")
-
-	m, err := rgbmatrix.NewRGBLedMatrix(config)
+	m, err := rgbmatrix.NewRGBLedMatrix(matrixConfig)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -52,7 +41,7 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	clockApp, err := clock.New(ctx)
+	clockApp, err := clock.New(ctx, cfg)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"github.com/caarlos0/env/v11"
+	"github.com/joho/godotenv"
+)
+
+type Settings struct {
+	// Weather
+	TomorrowIOAPIKey string `env:"TOMORROWIO_API_KEY,required"`
+	WeatherLatitude  string `env:"WEATHER_LATITUDE,required"`
+	WeatherLongitude string `env:"WEATHER_LONGITUDE,required"`
+	WeatherRefresh   int    `env:"WEATHER_REFRESH"    envDefault:"1800"`
+
+	// Clock
+	Timezone string `env:"TIMEZONE" envDefault:"Europe/London"`
+	Debug    bool   `env:"DEBUG"    envDefault:"false"`
+
+	// Calendar
+	CalendarFiles []string `env:"CALENDAR_FILES" envSeparator:","`
+
+	// LED hardware
+	LEDRows       int    `env:"LED_ROWS"       envDefault:"32"`
+	LEDCols       int    `env:"LED_COLS"       envDefault:"64"`
+	LEDPWMBits    int    `env:"LED_PWM_BITS"   envDefault:"11"`
+	LEDPWMLSBNano int    `env:"LED_PWM_LSB"    envDefault:"130"`
+	LEDBrightness int    `env:"LED_BRIGHTNESS" envDefault:"30"`
+	LEDHardware   string `env:"LED_HARDWARE"   envDefault:"adafruit-hat"`
+
+	// Home Assistant (all optional — only used when all three are set)
+	HAURL     string   `env:"HA_URL"`
+	HAToken   string   `env:"HA_TOKEN"`
+	HASensors []string `env:"HA_SENSORS" envSeparator:","`
+}
+
+func Load() (*Settings, error) {
+	// Best-effort: real environment variables take precedence over .env file.
+	_ = godotenv.Load()
+
+	s := &Settings{}
+	if err := env.Parse(s); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 
 require (
 	github.com/BurntSushi/xgb v0.0.0-20210121224620-deaf085860bc // indirect
+	github.com/caarlos0/env/v11 v11.4.0 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	golang.org/x/exp v0.0.0-20190301171323-01c40f57f5f6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/xgb v0.0.0-20210121224620-deaf085860bc h1:7D+Bh06CRPCJO3gr2F7h1sriovOZ8BMhca2Rg85c2nk=
 github.com/BurntSushi/xgb v0.0.0-20210121224620-deaf085860bc/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/caarlos0/env/v11 v11.4.0 h1:Kcb6t5kIIr4XkoQC9AF2j+8E1Jsrl3Wz/hhm1LtoGAc=
+github.com/caarlos0/env/v11 v11.4.0/go.mod h1:qupehSf/Y0TUTsxKywqRt/vJjN5nz6vauiYEUUr8P4U=
 github.com/go-gl/gl v0.0.0-20231021071112-07e5d0ea2e71 h1:5BVwOaUSBTlVZowGO6VZGw2H/zl9nrd3eCZfYV+NfQA=
 github.com/go-gl/gl v0.0.0-20231021071112-07e5d0ea2e71/go.mod h1:9YTyiznxEY1fVinfM7RvRcjRHbw2xLBJ3AAGIT0I4Nw=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20250301202403-da16c1255728 h1:RkGhqHxEVAvPM0/R+8g7XRwQnHatO0KAuVcwHo8q9W8=

--- a/internal/calendar/calendar.go
+++ b/internal/calendar/calendar.go
@@ -53,10 +53,8 @@ func (s eventList) Less(i, j int) bool {
 }
 
 // Load initialises the calendar. It parses the embedded default event files
-// and any additional YAML files listed in the CALENDAR_FILES environment
-// variable (comma-separated paths). Call this after loading environment
-// variables (e.g. via godotenv).
-func Load() error {
+// and any additional YAML files provided in the files slice.
+func Load(files []string) error {
 	f1Img, _, err := image.Decode(bytes.NewReader(f1ImageSource))
 	if err != nil {
 		return fmt.Errorf("calendar: failed to decode builtin f1 image: %w", err)
@@ -79,7 +77,7 @@ func Load() error {
 
 	all := defaults
 
-	for _, path := range splitPaths(os.Getenv("CALENDAR_FILES")) {
+	for _, path := range files {
 		data, err := os.ReadFile(path)
 		if err != nil {
 			log.Printf("calendar: skipping file %q: %v", path, err)
@@ -181,15 +179,3 @@ func resolveImage(ref string, dir string) image.Image {
 	return img
 }
 
-func splitPaths(env string) []string {
-	if env == "" {
-		return nil
-	}
-	var paths []string
-	for _, p := range strings.Split(env, ",") {
-		if p = strings.TrimSpace(p); p != "" {
-			paths = append(paths, p)
-		}
-	}
-	return paths
-}


### PR DESCRIPTION
## Summary

Replaces ad-hoc `os.Getenv` calls scattered across the codebase with a single `config` package that owns all settings loading. Introduces `caarlos0/env` v11 for struct-tag-based env var parsing.

## Changes

### New: `config/config.go`
- `Settings` struct covering all environment variables across the application, annotated with `env` struct tags
- Required fields (`TOMORROWIO_API_KEY`, `WEATHER_LATITUDE`, `WEATHER_LONGITUDE`) produce a descriptive error at startup if missing
- Optional fields have sensible defaults via `envDefault` tags (`TIMEZONE=Europe/London`, `WEATHER_REFRESH=1800`, LED hardware defaults, etc.)
- Optional feature flags (`HA_URL`, `HA_TOKEN`, `HA_SENSORS`, `CALENDAR_FILES`) are zero-valued when not set
- `Load()` calls `godotenv.Load()` best-effort (no error if `.env` is absent — real env vars take precedence) then parses via `env.Parse`

### `clock/clock.go`
- `New()` signature changed to `New(ctx context.Context, cfg *config.Settings)` — no longer responsible for loading env vars
- Removed imports: `os`, `strconv`, `errors`, `godotenv`
- `CALENDAR_FILES` splitting removed; `cfg.HASensors` is already `[]string`
- `TIMEZONE` default logic replaced by the struct tag default

### `internal/calendar/calendar.go`
- `Load()` changed to `Load(files []string)` — caller passes the file list, no internal env var read
- `splitPaths` helper removed

### `cmd/pi/main.go`, `cmd/debug/main.go`, `cmd/debug-window/main.go`
- `init()` functions removed
- Each `main()` now calls `config.Load()` once at startup and passes `cfg` to `clock.New()`
- LED matrix integer settings (`LED_ROWS`, `LED_COLS`, etc.) are typed `int` from config rather than `strconv.ParseInt` on raw env strings

### `go.mod` / `go.sum`
- Added `github.com/caarlos0/env/v11 v11.4.0`

https://claude.ai/code/session_015PUnrZ8ZJ8J2x2sfpWvTwv