### PR TITLE
Add moon phase page and extend daylight page with moonrise/moonset

### DIFF
--- a/clock/clock.go
+++ b/clock/clock.go
@@ -91,6 +91,7 @@ func New(ctx context.Context, cfg *config.Settings) (*ClockRenderer, error) {
 		r.renderToday,
 		r.renderTomorrow,
 		r.renderDaylight,
+		r.renderMoon,
 		r.renderCountdown,
 		r.renderDiag,
 	}

--- a/clock/pages_moon.go
+++ b/clock/pages_moon.go
@@ -6,9 +6,12 @@ import (
 	"math"
 	"time"
 
+	"github.com/g-wilson/led/internal/huegradient"
 	"github.com/soniakeys/meeus/v3/julian"
 	"github.com/soniakeys/meeus/v3/moonillum"
 )
+
+var colourMoon = huegradient.Gradient{BaseHue: 240}.Color(0) // cool blue
 
 func moonPhaseIllumination(t time.Time) (illum float64, waxing bool) {
 	jde := julian.TimeToJD(t)
@@ -50,6 +53,8 @@ func drawMoonDisc(c *image.RGBA, centre image.Point, radius int, illum float64, 
 
 	r2 := radius * radius
 	for dy := -radius; dy <= radius; dy++ {
+		hw := math.Sqrt(float64(r2 - dy*dy))
+		termX := hw * (1 - 2*illum)
 		for dx := -radius; dx <= radius; dx++ {
 			if dx*dx+dy*dy > r2 {
 				continue
@@ -59,8 +64,6 @@ func drawMoonDisc(c *image.RGBA, centre image.Point, radius int, illum float64, 
 			if !image.Pt(px, py).In(c.Bounds()) {
 				continue
 			}
-			hw := math.Sqrt(float64(r2 - dy*dy))
-			termX := hw * (1 - 2*illum)
 			var lit bool
 			if waxing {
 				lit = float64(dx) >= termX
@@ -83,7 +86,7 @@ func (r *ClockRenderer) renderMoon(c *image.RGBA) error {
 	drawMoonDisc(c, image.Point{X: 32, Y: 19}, 7, illum, waxing)
 
 	centreX := 32 - (4*len(name))/2
-	r.addText(c, image.Point{X: centreX, Y: 29}, name, colourMoonrise)
+	r.addText(c, image.Point{X: centreX, Y: 29}, name, colourMoon)
 
 	return nil
 }

--- a/clock/pages_moon.go
+++ b/clock/pages_moon.go
@@ -83,10 +83,10 @@ func (r *ClockRenderer) renderMoon(c *image.RGBA) error {
 	illum, waxing := moonPhaseIllumination(time.Now())
 	name := moonPhaseName(illum, waxing)
 
-	drawMoonDisc(c, image.Point{X: 32, Y: 19}, 7, illum, waxing)
+	drawMoonDisc(c, image.Point{X: 32, Y: 15}, 9, illum, waxing)
 
 	centreX := 32 - (4*len(name))/2
-	r.addText(c, image.Point{X: centreX, Y: 29}, name, colourMoon)
+	r.addText(c, image.Point{X: centreX, Y: 26}, name, colourMoon)
 
 	return nil
 }

--- a/clock/pages_moon.go
+++ b/clock/pages_moon.go
@@ -1,0 +1,89 @@
+package clock
+
+import (
+	"image"
+	"image/color"
+	"math"
+	"time"
+
+	"github.com/soniakeys/meeus/v3/julian"
+	"github.com/soniakeys/meeus/v3/moonillum"
+)
+
+func moonPhaseIllumination(t time.Time) (illum float64, waxing bool) {
+	jde := julian.TimeToJD(t)
+	angle := moonillum.PhaseAngle3(jde)
+	illum = (1 + math.Cos(float64(angle))) / 2
+
+	// compare to 12 hours ahead to determine waxing vs waning
+	jdeFuture := julian.TimeToJD(t.Add(12 * time.Hour))
+	angleFuture := moonillum.PhaseAngle3(jdeFuture)
+	illumFuture := (1 + math.Cos(float64(angleFuture))) / 2
+	waxing = illumFuture > illum
+	return
+}
+
+func moonPhaseName(illum float64, waxing bool) string {
+	switch {
+	case illum < 0.02:
+		return "New Moon"
+	case illum > 0.98:
+		return "Full Moon"
+	case illum < 0.48 && waxing:
+		return "Wax Crescent"
+	case illum >= 0.48 && illum <= 0.52 && waxing:
+		return "1st Quarter"
+	case illum > 0.52 && waxing:
+		return "Wax Gibbous"
+	case illum > 0.52:
+		return "Wan Gibbous"
+	case illum >= 0.48 && illum <= 0.52:
+		return "3rd Quarter"
+	default:
+		return "Wan Crescent"
+	}
+}
+
+func drawMoonDisc(c *image.RGBA, centre image.Point, radius int, illum float64, waxing bool) {
+	litColour := color.RGBA{210, 215, 230, 255}
+	darkColour := color.RGBA{25, 25, 45, 255}
+
+	r2 := radius * radius
+	for dy := -radius; dy <= radius; dy++ {
+		for dx := -radius; dx <= radius; dx++ {
+			if dx*dx+dy*dy > r2 {
+				continue
+			}
+			px := centre.X + dx
+			py := centre.Y + dy
+			if !image.Pt(px, py).In(c.Bounds()) {
+				continue
+			}
+			hw := math.Sqrt(float64(r2 - dy*dy))
+			termX := hw * (1 - 2*illum)
+			var lit bool
+			if waxing {
+				lit = float64(dx) >= termX
+			} else {
+				lit = float64(dx) <= -termX
+			}
+			if lit {
+				c.SetRGBA(px, py, litColour)
+			} else {
+				c.SetRGBA(px, py, darkColour)
+			}
+		}
+	}
+}
+
+func (r *ClockRenderer) renderMoon(c *image.RGBA) error {
+	illum, waxing := moonPhaseIllumination(time.Now())
+	name := moonPhaseName(illum, waxing)
+
+	drawMoonDisc(c, image.Point{X: 32, Y: 19}, 7, illum, waxing)
+
+	centreX := 32 - (4*len(name))/2
+	r.addText(c, image.Point{X: centreX, Y: 29}, name, colourMoonrise)
+
+	return nil
+}

--- a/clock/pages_weather.go
+++ b/clock/pages_weather.go
@@ -32,19 +32,20 @@ var (
 
 func (r *ClockRenderer) renderDaylight(c *image.RGBA) error {
 	w := r.weather.GetToday()
+	xOffset := 2
 
 	sunrise := w.SunriseTime.In(r.location).Format("15:04")
 	sunset := w.SunsetTime.In(r.location).Format("15:04")
-	r.addText(c, image.Point{X: 0, Y: 8}, fmt.Sprintf("Sunrise %s", sunrise), colourSunrise)
-	r.addText(c, image.Point{X: 0, Y: 14}, fmt.Sprintf("Sunset  %s", sunset), colourSunset)
+	r.addText(c, image.Point{X: xOffset, Y: 8}, fmt.Sprintf(" Sunrise %s", sunrise), colourSunrise)
+	r.addText(c, image.Point{X: xOffset, Y: 14}, fmt.Sprintf("  Sunset %s", sunset), colourSunset)
 
 	if !w.MoonriseTime.IsZero() {
 		moonrise := w.MoonriseTime.In(r.location).Format("15:04")
-		r.addText(c, image.Point{X: 0, Y: 20}, fmt.Sprintf("Moonrise %s", moonrise), colourMoonrise)
+		r.addText(c, image.Point{X: xOffset, Y: 20}, fmt.Sprintf("Moonrise %s", moonrise), colourMoonrise)
 	}
 	if !w.MoonsetTime.IsZero() {
 		moonset := w.MoonsetTime.In(r.location).Format("15:04")
-		r.addText(c, image.Point{X: 0, Y: 26}, fmt.Sprintf("Moonset  %s", moonset), colourMoonset)
+		r.addText(c, image.Point{X: xOffset, Y: 26}, fmt.Sprintf(" Moonset %s", moonset), colourMoonset)
 	}
 
 	return nil

--- a/clock/pages_weather.go
+++ b/clock/pages_weather.go
@@ -24,10 +24,10 @@ func (r *ClockRenderer) renderTomorrow(c *image.RGBA) error {
 }
 
 var (
-	colourSunrise  = huegradient.Gradient{BaseHue: 80, Step: 0}.Color(0)  // warm golden yellow
-	colourSunset   = huegradient.Gradient{BaseHue: 30, Step: 0}.Color(0)  // warm amber-orange
-	colourMoonrise = huegradient.Gradient{BaseHue: 240, Step: 0}.Color(0) // cool blue
-	colourMoonset  = huegradient.Gradient{BaseHue: 280, Step: 0}.Color(0) // cool blue-violet
+	colourSunrise  = huegradient.Gradient{BaseHue: 80}.Color(0)  // warm golden yellow
+	colourSunset   = huegradient.Gradient{BaseHue: 30}.Color(0)  // warm amber-orange
+	colourMoonrise = huegradient.Gradient{BaseHue: 240}.Color(0) // cool blue
+	colourMoonset  = huegradient.Gradient{BaseHue: 280}.Color(0) // cool blue-violet
 )
 
 func (r *ClockRenderer) renderDaylight(c *image.RGBA) error {

--- a/clock/pages_weather.go
+++ b/clock/pages_weather.go
@@ -5,6 +5,7 @@ import (
 	"image"
 	"image/color"
 
+	"github.com/g-wilson/led/internal/huegradient"
 	"github.com/g-wilson/led/internal/weather"
 )
 
@@ -22,12 +23,30 @@ func (r *ClockRenderer) renderTomorrow(c *image.RGBA) error {
 	return nil
 }
 
+var (
+	colourSunrise  = huegradient.Gradient{BaseHue: 80, Step: 0}.Color(0)  // warm golden yellow
+	colourSunset   = huegradient.Gradient{BaseHue: 30, Step: 0}.Color(0)  // warm amber-orange
+	colourMoonrise = huegradient.Gradient{BaseHue: 240, Step: 0}.Color(0) // cool blue
+	colourMoonset  = huegradient.Gradient{BaseHue: 280, Step: 0}.Color(0) // cool blue-violet
+)
+
 func (r *ClockRenderer) renderDaylight(c *image.RGBA) error {
 	w := r.weather.GetToday()
-	sunrise := w.SunriseTime.UTC().In(r.location).Format("15:04")
-	sunset := w.SunsetTime.UTC().In(r.location).Format("15:04")
-	r.addText(c, image.Point{X: 4, Y: 10}, fmt.Sprintf("Sunrise %s", sunrise), color.RGBA{152, 168, 27, 255})
-	r.addText(c, image.Point{X: 8, Y: 18}, fmt.Sprintf("Sunset %s", sunset), color.RGBA{194, 27, 27, 255})
+
+	sunrise := w.SunriseTime.In(r.location).Format("15:04")
+	sunset := w.SunsetTime.In(r.location).Format("15:04")
+	r.addText(c, image.Point{X: 0, Y: 8}, fmt.Sprintf("Sunrise %s", sunrise), colourSunrise)
+	r.addText(c, image.Point{X: 0, Y: 14}, fmt.Sprintf("Sunset  %s", sunset), colourSunset)
+
+	if !w.MoonriseTime.IsZero() {
+		moonrise := w.MoonriseTime.In(r.location).Format("15:04")
+		r.addText(c, image.Point{X: 0, Y: 20}, fmt.Sprintf("Moonrise %s", moonrise), colourMoonrise)
+	}
+	if !w.MoonsetTime.IsZero() {
+		moonset := w.MoonsetTime.In(r.location).Format("15:04")
+		r.addText(c, image.Point{X: 0, Y: 26}, fmt.Sprintf("Moonset  %s", moonset), colourMoonset)
+	}
+
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,8 @@ require (
 	github.com/caarlos0/env/v11 v11.4.0 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
+	github.com/soniakeys/meeus/v3 v3.0.1 // indirect
+	github.com/soniakeys/unit v1.0.0 // indirect
 	golang.org/x/exp v0.0.0-20190301171323-01c40f57f5f6 // indirect
 	golang.org/x/mobile v0.0.0-20190302063618-b8c6dab863a6 // indirect
 	golang.org/x/sys v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,11 @@ github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQ
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mcuadros/go-rpi-rgb-led-matrix v0.0.0-20180401002551-b26063b3169a h1:LW0Q1rpZM0IvF0VsC8f1FrmHxG9UZrAY/jF6W+iZBo4=
 github.com/mcuadros/go-rpi-rgb-led-matrix v0.0.0-20180401002551-b26063b3169a/go.mod h1:6p7/C4Toq+GhRHIR7gmxjiNYRYYwh9zQeVJa/xmbqLU=
+github.com/soniakeys/meeus/v3 v3.0.1 h1:inZIhWUeyumGoQ//CCZMI4qR2vPKCS6LbVPca2mDvqE=
+github.com/soniakeys/meeus/v3 v3.0.1/go.mod h1:G1tkqa+QcOyErSe7WqN0OnzVeLrvq9bQBoNb1IG+3n8=
+github.com/soniakeys/sexagesimal v1.0.0/go.mod h1:/7psACvkUx/IZ1XX3HDdBci1Lz1ZObcjLX2MVVKI3rM=
+github.com/soniakeys/unit v1.0.0 h1:UMIgu6dxDQaK6tYaQV6dJn5oovB6035KRxCS0O7Jiec=
+github.com/soniakeys/unit v1.0.0/go.mod h1:z93o2tO/hJA2+Wr1Fozkt3jK4LyDwTfRCjyRFLAa4zk=
 github.com/toelsiba/fopix v0.0.0-20210114151512-ed880dcce00d h1:9I5tYQcUAH58Qopu9NbUolh6rTAa/uZUm38ywvNCPAw=
 github.com/toelsiba/fopix v0.0.0-20210114151512-ed880dcce00d/go.mod h1:/atAwnnhAmnjdOslj7TNBen9M4b6XADH5cJNiZ1G+q4=
 golang.org/x/exp v0.0.0-20190301171323-01c40f57f5f6 h1:75bC0RF0WtaWl7tKKq99XxDxjYTu0d4iy6yh7TcErbk=

--- a/internal/tomorrowio/types.go
+++ b/internal/tomorrowio/types.go
@@ -132,6 +132,8 @@ func (d Values) ToDomain() weather.DayWeather {
 		TemperatureLow:  float32(d.TemperatureMin),
 		SunriseTime:     d.SunriseTime,
 		SunsetTime:      d.SunsetTime,
+		MoonriseTime:    d.MoonriseTime,
+		MoonsetTime:     d.MoonsetTime,
 		Rainy:           d.PrecipitationProbabilityAvg > 25,
 		Windy:           d.WindSpeedAvg > 6 || d.WindGustAvg > 12,
 		Cloudy:          d.CloudCoverAvg > 80,

--- a/internal/weather/agent.go
+++ b/internal/weather/agent.go
@@ -15,6 +15,8 @@ type DayWeather struct {
 	TemperatureLow  float32
 	SunriseTime     time.Time
 	SunsetTime      time.Time
+	MoonriseTime    time.Time
+	MoonsetTime     time.Time
 	Rainy           bool
 	Windy           bool
 	Cloudy          bool


### PR DESCRIPTION
- New renderMoon page: pixel-art disc visualisation using meeus/v3 phase
  angle calculation, with phase name centred below
- renderDaylight extended: shows all four times (sunrise, sunset, moonrise,
  moonset) using Oklch huegradient colours — warm for sun, cool for moon
- Forward MoonriseTime/MoonsetTime from Tomorrow.io API through to DayWeather
- Add github.com/soniakeys/meeus/v3 for astronomically accurate phase calculations

https://claude.ai/code/session_01Xe4G7qCdSd2uW4sTT7cgov