### PR TITLE
Add air quality monitoring page using Air Matters API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ WEATHER_LATITUDE=xxxx
 WEATHER_LONGITUDE=xxxx
 WEATHER_REFRESH=1800
 
+# Air Quality (optional) — shows AQI, PM2.5, and O3 readings.
+# Uses the same lat/lon as weather. Omit to disable the page.
+AIRMATTERS_API_KEY=xxxx
+
 # Home Assistant
 
 # Sensor pages — one page per area, shows entity state values.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ WEATHER_LONGITUDE=xxxx
 WEATHER_REFRESH=1800
 
 # Air Quality (optional) — shows AQI, PM2.5, and O3 readings.
-# Uses the same lat/lon as weather. Omit to disable the page.
+# Uses the same lat/lon as weather. Omit AIRMATTERS_API_KEY to disable the page.
 AIRMATTERS_API_KEY=xxxx
+AIRMATTERS_REFRESH=7200
 
 # Home Assistant
 

--- a/clock/clock.go
+++ b/clock/clock.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/g-wilson/led/config"
+	"github.com/g-wilson/led/internal/airmatters"
 	"github.com/g-wilson/led/internal/calendar"
 	"github.com/g-wilson/led/internal/diagnostics"
 	"github.com/g-wilson/led/internal/hamediaplayer"
@@ -36,6 +37,7 @@ type ClockRenderer struct {
 	diagnostics  *diagnostics.Agent
 	sensors      *hasensors.Agent
 	mediaPlayer  *hamediaplayer.Agent
+	airQuality   *airmatters.Agent
 	location     *time.Location
 	pages        []page
 	currentPage  atomic.Int32
@@ -114,7 +116,23 @@ func New(ctx context.Context, cfg *config.Settings) (*ClockRenderer, error) {
 		}
 	}
 
-	// Phase 3: media player page (skipped if HA settings or player list not provided)
+	// Phase 3: air quality page (skipped if API key not provided)
+	if cfg.AirMattersAPIKey != "" {
+		amClient := airmatters.New(cfg.AirMattersAPIKey, nil)
+		amAgent, err := airmatters.NewAgent(ctx, amClient, airmatters.AgentOptions{
+			Latitude:  cfg.WeatherLatitude,
+			Longitude: cfg.WeatherLongitude,
+			Refresh:   cfg.AirMattersRefresh,
+		})
+		if err != nil {
+			log.Printf("air quality agent unavailable, skipping air quality page: %v", err)
+		} else {
+			r.airQuality = amAgent
+			r.pages = append(r.pages, r.renderAirQuality)
+		}
+	}
+
+	// Phase 4: media player page (skipped if HA settings or player list not provided)
 	if cfg.HAURL != "" && cfg.HAToken != "" && len(cfg.HAMediaPlayers) > 0 {
 		haClient := homeassistant.New(cfg.HAURL, cfg.HAToken, nil)
 		mediaAgent, err := hamediaplayer.New(ctx, haClient, cfg.HAMediaPlayers)

--- a/clock/pages_airquality.go
+++ b/clock/pages_airquality.go
@@ -1,0 +1,23 @@
+package clock
+
+import (
+	"fmt"
+	"image"
+	"image/color"
+)
+
+var _ page = (*ClockRenderer)(nil).renderAirQuality
+
+func (r *ClockRenderer) renderAirQuality(c *image.RGBA) error {
+	air := r.airQuality.Get()
+
+	r.addText(c, image.Point{X: 0, Y: 8}, "Air Quality", color.RGBA{180, 180, 180, 255})
+
+	aqiText := fmt.Sprintf("AQI %s %s", air.AQI.Value, air.AQI.Level)
+	r.addText(c, image.Point{X: 0, Y: 15}, aqiText, air.AQI.Color)
+
+	pm25Text := fmt.Sprintf("PM2.5 %s", air.PM25.Value)
+	r.addText(c, image.Point{X: 0, Y: 22}, pm25Text, air.PM25.Color)
+
+	return nil
+}

--- a/clock/pages_airquality.go
+++ b/clock/pages_airquality.go
@@ -14,10 +14,13 @@ func (r *ClockRenderer) renderAirQuality(c *image.RGBA) error {
 	r.addText(c, image.Point{X: 0, Y: 8}, "Air Quality", color.RGBA{180, 180, 180, 255})
 
 	aqiText := fmt.Sprintf("AQI %s %s", air.AQI.Value, air.AQI.Level)
-	r.addText(c, image.Point{X: 0, Y: 15}, aqiText, air.AQI.Color)
+	r.addText(c, image.Point{X: 0, Y: 14}, aqiText, air.AQI.Color)
 
 	pm25Text := fmt.Sprintf("PM2.5 %s", air.PM25.Value)
-	r.addText(c, image.Point{X: 0, Y: 22}, pm25Text, air.PM25.Color)
+	r.addText(c, image.Point{X: 0, Y: 20}, pm25Text, air.PM25.Color)
+
+	o3Text := fmt.Sprintf("O3 %s", air.O3.Value)
+	r.addText(c, image.Point{X: 0, Y: 26}, o3Text, air.O3.Color)
 
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -29,7 +29,7 @@ type Settings struct {
 
 	// Air Matters (optional — skipped if API key not set)
 	AirMattersAPIKey string `env:"AIRMATTERS_API_KEY"`
-	AirMattersRefresh int   `env:"AIRMATTERS_REFRESH" envDefault:"1800"`
+	AirMattersRefresh int   `env:"AIRMATTERS_REFRESH" envDefault:"21600"`
 
 	// Home Assistant (all optional — only used when all three are set)
 	HAURL          string   `env:"HA_URL"`

--- a/config/config.go
+++ b/config/config.go
@@ -29,7 +29,7 @@ type Settings struct {
 
 	// Air Matters (optional — skipped if API key not set)
 	AirMattersAPIKey string `env:"AIRMATTERS_API_KEY"`
-	AirMattersRefresh int   `env:"AIRMATTERS_REFRESH" envDefault:"21600"`
+	AirMattersRefresh int   `env:"AIRMATTERS_REFRESH" envDefault:"7200"`
 
 	// Home Assistant (all optional — only used when all three are set)
 	HAURL          string   `env:"HA_URL"`

--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,10 @@ type Settings struct {
 	LEDBrightness int    `env:"LED_BRIGHTNESS" envDefault:"30"`
 	LEDHardware   string `env:"LED_HARDWARE"   envDefault:"adafruit-hat"`
 
+	// Air Matters (optional — skipped if API key not set)
+	AirMattersAPIKey string `env:"AIRMATTERS_API_KEY"`
+	AirMattersRefresh int   `env:"AIRMATTERS_REFRESH" envDefault:"1800"`
+
 	// Home Assistant (all optional — only used when all three are set)
 	HAURL          string   `env:"HA_URL"`
 	HAToken        string   `env:"HA_TOKEN"`

--- a/internal/airmatters/agent.go
+++ b/internal/airmatters/agent.go
@@ -1,0 +1,81 @@
+package airmatters
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+)
+
+const fetchTimeout = 15 * time.Second
+
+type Agent struct {
+	ctx     context.Context
+	client  *Client
+	options AgentOptions
+
+	mu   sync.RWMutex
+	data AirCondition
+}
+
+type AgentOptions struct {
+	Latitude  string
+	Longitude string
+	Refresh   int
+}
+
+func NewAgent(ctx context.Context, client *Client, options AgentOptions) (*Agent, error) {
+	a := &Agent{
+		ctx:     ctx,
+		client:  client,
+		options: options,
+	}
+
+	if err := a.populateCache(); err != nil {
+		return nil, err
+	}
+
+	go func() {
+		ticker := time.NewTicker(time.Duration(options.Refresh) * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := a.populateCache(); err != nil {
+					log.Println(fmt.Errorf("error fetching air quality: %w", err))
+				}
+			}
+		}
+	}()
+
+	return a, nil
+}
+
+func (a *Agent) populateCache() error {
+	log.Println("fetching air quality")
+
+	ctx, cancel := context.WithTimeout(a.ctx, fetchTimeout)
+	defer cancel()
+
+	data, err := a.client.GetNearbyAirCondition(ctx, a.options.Latitude, a.options.Longitude)
+	if err != nil {
+		return err
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.data = data
+
+	return nil
+}
+
+func (a *Agent) Get() AirCondition {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	return a.data
+}

--- a/internal/airmatters/client.go
+++ b/internal/airmatters/client.go
@@ -91,6 +91,12 @@ func (r Response) toDomain() AirCondition {
 				Level: reading.Level,
 				Color: parseHexColor(reading.Color),
 			}
+		case "o3":
+			ac.O3 = ReadingData{
+				Value: reading.Value,
+				Level: reading.Level,
+				Color: parseHexColor(reading.Color),
+			}
 		}
 	}
 	return ac

--- a/internal/airmatters/client.go
+++ b/internal/airmatters/client.go
@@ -1,0 +1,110 @@
+package airmatters
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"image/color"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+type Client struct {
+	apiKey string
+	client *http.Client
+}
+
+func New(apiKey string, client *http.Client) *Client {
+	if client == nil {
+		client = &http.Client{
+			Timeout: time.Second * 10,
+		}
+	}
+
+	return &Client{
+		client: client,
+		apiKey: apiKey,
+	}
+}
+
+func (c *Client) GetNearbyAirCondition(ctx context.Context, lat, lon string) (AirCondition, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://api.air-matters.app/nearby_air_condition", nil)
+	if err != nil {
+		return AirCondition{}, err
+	}
+
+	req.URL.RawQuery = url.Values{
+		"lat":      []string{lat},
+		"lon":      []string{lon},
+		"lang":     []string{"en"},
+		"standard": []string{"aqi_us"},
+	}.Encode()
+
+	req.Header.Add("Authorization", c.apiKey)
+	req.Header.Add("Accept", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return AirCondition{}, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return AirCondition{}, err
+	}
+
+	switch {
+	case resp.StatusCode > 499:
+		return AirCondition{}, errors.New(resp.Status)
+	case resp.StatusCode >= 400:
+		return AirCondition{}, fmt.Errorf("air matters api error: %s", resp.Status)
+	}
+
+	var r Response
+	if err := json.Unmarshal(body, &r); err != nil {
+		return AirCondition{}, err
+	}
+
+	return r.toDomain(), nil
+}
+
+func (r Response) toDomain() AirCondition {
+	ac := AirCondition{
+		PlaceName: r.Place.Name,
+	}
+	for _, reading := range r.Latest.Readings {
+		switch reading.Kind {
+		case "aqi":
+			ac.AQI = ReadingData{
+				Value: reading.Value,
+				Level: reading.Level,
+				Color: parseHexColor(reading.Color),
+			}
+		case "pm25":
+			ac.PM25 = ReadingData{
+				Value: reading.Value,
+				Level: reading.Level,
+				Color: parseHexColor(reading.Color),
+			}
+		}
+	}
+	return ac
+}
+
+func parseHexColor(s string) color.RGBA {
+	if len(s) != 7 || s[0] != '#' {
+		return color.RGBA{200, 200, 200, 255}
+	}
+	r, err1 := strconv.ParseUint(s[1:3], 16, 8)
+	g, err2 := strconv.ParseUint(s[3:5], 16, 8)
+	b, err3 := strconv.ParseUint(s[5:7], 16, 8)
+	if err1 != nil || err2 != nil || err3 != nil {
+		return color.RGBA{200, 200, 200, 255}
+	}
+	return color.RGBA{uint8(r), uint8(g), uint8(b), 255}
+}

--- a/internal/airmatters/types.go
+++ b/internal/airmatters/types.go
@@ -1,0 +1,42 @@
+package airmatters
+
+import "image/color"
+
+type Response struct {
+	Place  Place  `json:"place"`
+	Latest Latest `json:"latest"`
+}
+
+type Place struct {
+	Lat     float64 `json:"lat"`
+	Lon     float64 `json:"lon"`
+	Name    string  `json:"name"`
+	Type    string  `json:"type"`
+	PlaceID string  `json:"place_id"`
+}
+
+type Latest struct {
+	Readings   []Reading `json:"readings"`
+	UpdateTime string    `json:"update_time"`
+}
+
+type Reading struct {
+	Name  string `json:"name"`
+	Kind  string `json:"kind"`
+	Color string `json:"color"`
+	Level string `json:"level"`
+	Value string `json:"value"`
+	Unit  string `json:"unit"`
+}
+
+type AirCondition struct {
+	PlaceName string
+	AQI       ReadingData
+	PM25      ReadingData
+}
+
+type ReadingData struct {
+	Value string
+	Level string
+	Color color.RGBA
+}

--- a/internal/airmatters/types.go
+++ b/internal/airmatters/types.go
@@ -33,6 +33,7 @@ type AirCondition struct {
 	PlaceName string
 	AQI       ReadingData
 	PM25      ReadingData
+	O3        ReadingData
 }
 
 type ReadingData struct {


### PR DESCRIPTION
## Summary
This PR adds air quality monitoring capabilities to the LED clock display by integrating with the Air Matters API. Users can now view real-time AQI, PM2.5, and O3 readings for their location on a dedicated page.

## Key Changes
- **New Air Matters client** (`internal/airmatters/client.go`): HTTP client for fetching nearby air condition data from the Air Matters API, with response parsing and hex color conversion
- **Air quality agent** (`internal/airmatters/agent.go`): Background agent that periodically fetches and caches air quality data with configurable refresh intervals
- **Type definitions** (`internal/airmatters/types.go`): Domain models for API responses and air quality readings
- **Air quality page renderer** (`clock/pages_airquality.go`): Displays AQI, PM2.5, and O3 readings with color-coded levels
- **Configuration support**: Added `AIRMATTERS_API_KEY` and `AIRMATTERS_REFRESH` environment variables to enable/configure the feature
- **Integration**: Wired air quality agent into the main clock renderer as an optional page (Phase 3)

## Notable Implementation Details
- The air quality page is optional and only enabled when `AIRMATTERS_API_KEY` is provided
- Reuses existing weather latitude/longitude configuration for location
- Implements thread-safe caching with RWMutex to prevent race conditions
- Graceful error handling with fallback gray color for invalid hex values
- 15-second timeout for API requests with configurable refresh interval (default 2 hours)

https://claude.ai/code/session_01VbQPnpKy6Ju3uR65CLH626